### PR TITLE
Fix bug, Move query to next line, simplify code

### DIFF
--- a/getsong/getsong.py
+++ b/getsong/getsong.py
@@ -8,6 +8,7 @@ except ImportError: # Python 2
 import argparse
 import youtube_dl
 from bs4 import BeautifulSoup as Soup
+from builtins import input
 from sys import exit, version_info
 
 
@@ -37,18 +38,14 @@ def main():
     if not uri:
         print("Could not find result for {}. http://youtube.com/results?{}".format(term, urlencode({'search_query': term})))
         return 2
+    response = input("About to download the audio for {}.\nIs this correct? [y/n] ".format(title))
     try:
-        input = raw_input
-    except NameError:
-        pass
-    try:
-        cont = args.yes or input("About to download the audio for {}, is this correct? [y] ".format(title)) or "y"
+        cont = args.yes or response in ['Y', 'y']
     except KeyboardInterrupt:
-        cont = "ctrl-c"
-        print("")
-    if cont in [True, "y", "Y", "yes", ""]:
+        cont = False
+    if cont:
         return get_video(uri)
-    print("Aborted.")
+    print("\nAborted.")
     return 0
 
 


### PR DESCRIPTION
I added a newline character to the download query because it's more convenient to not have to scroll to the end of a window just to see that you're supposed to type 'y'.

There was an unnoticed bug in the `cont = args.yes or etc etc etc or "y"` line in that `"y"` is a non-empty string, so it will always return true (Since the input was not checked for equality to the desired strings it would always return True as well). This means that no matter what the user entered, the Boolean `cont` would always evaluate to `True`. I fixed this and trimmed up the `if` statement that is now on line 46, replacing the unnecessary `if cont in [True, "y", "Y", "yes", ""]:` statement (Since `cont` is already a Boolean) with simply `if cont:`

Other than that I'm enjoying the program and may start using it in larger projects or for my own convenience.
